### PR TITLE
1.2.2

### DIFF
--- a/Academia Arcana Victory/Suplementos/L6_Lacos_e_Mascaras/cap05_progressao_de_vinculo.md
+++ b/Academia Arcana Victory/Suplementos/L6_Lacos_e_Mascaras/cap05_progressao_de_vinculo.md
@@ -5,7 +5,7 @@
 
 ## Introdução: Um Sistema, Três Sabores
 
-As três franquias deste livro desenvolveram, de forma independente, mecânicas para a mesma percepção: vínculos entre personagens têm peso que vai além do roleplay.
+Os três sistemas deste livro desenvolveram, de forma independente, mecânicas para a mesma percepção: vínculos entre personagens têm peso que vai além do roleplay.
 
 - **Sintonia de Time** (Academia Ninja) — o grupo como unidade coesa tem bônus táticos que indivíduos isolados não têm
 - **Força dos Laços** (Chama Livre) — proteger quem você ama libera poder que treino normal não alcança
@@ -13,7 +13,7 @@ As três franquias deste livro desenvolveram, de forma independente, mecânicas 
 
 Este capítulo unifica esses três sistemas em um framework único chamado **Vínculos de Campanha**. O framework tem três camadas opcionais: você pode usar apenas a primeira, as duas primeiras, ou as três — a cada adição, o sistema fica mais granular mas também mais comprometido com rastreamento.
 
-> **Regra de Ouro Mecânica:** este livro adiciona no máximo 2 subsistemas simultâneos à sua campanha. Recomendado: Vínculos de Campanha (este capítulo) + 1 subsistema de franquia à escolha (Controle de Chakra, Dragon Slayer, ou Vida Dupla). Usar todos os três subsistemas de franquia ao mesmo tempo não é recomendado.
+> **Regra de Ouro Mecânica:** este livro adiciona no máximo 2 subsistemas simultâneos à sua campanha. Recomendado: Vínculos de Campanha (este capítulo) + 1 subsistema à escolha (Canalização Dupla, Magia de Origem, ou Vida Dupla). Usar todos os três subsistemas ao mesmo tempo não é recomendado.
 
 ---
 

--- a/docs/js/content-map.js
+++ b/docs/js/content-map.js
@@ -54,20 +54,9 @@ const CONTENT_MAP = [
   },
 
   {
-    id: 'suplementos',
-    group: 'academia',
-    title: 'Suplementos',
-    subtitle: 'Visão Geral',
-    path: 'Academia Arcana Victory/Suplementos',
-    chapters: [
-      { id: 'indice', file: 'INDICE_SUPLEMENTOS.md', title: 'Índice de Suplementos' },
-    ],
-  },
-
-  {
     id: 'l0',
     group: 'academia',
-    title: 'L0 — A Verdade da Arca',
+    title: 'A Verdade da Arca',
     subtitle: 'Suspense institucional',
     path: 'Academia Arcana Victory/Suplementos/L0_A_Verdade_da_Arca',
     chapters: [
@@ -85,7 +74,7 @@ const CONTENT_MAP = [
   {
     id: 'l1',
     group: 'academia',
-    title: 'L1 — Estrelas & Cristais',
+    title: 'Estrelas & Cristais',
     subtitle: 'Luminoso, épico, otimista',
     path: 'Academia Arcana Victory/Suplementos/L1_Estrelas_e_Cristais',
     chapters: [
@@ -105,7 +94,7 @@ const CONTENT_MAP = [
   {
     id: 'l2',
     group: 'academia',
-    title: 'L2 — Tinta & Sombras',
+    title: 'Tinta & Sombras',
     subtitle: 'Sombrio, horror atmosférico',
     path: 'Academia Arcana Victory/Suplementos/L2_Tinta_e_Sombras',
     chapters: [
@@ -125,7 +114,7 @@ const CONTENT_MAP = [
   {
     id: 'l3',
     group: 'academia',
-    title: 'L3 — Palavras de Poder',
+    title: 'Palavras de Poder',
     subtitle: 'Contemplativo, rigoroso',
     path: 'Academia Arcana Victory/Suplementos/L3_Palavras_de_Poder',
     chapters: [
@@ -143,7 +132,7 @@ const CONTENT_MAP = [
   {
     id: 'l4',
     group: 'academia',
-    title: 'L4 — Sangue & Legado',
+    title: 'Sangue & Legado',
     subtitle: 'Aventureiro, institucional',
     path: 'Academia Arcana Victory/Suplementos/L4_Sangue_e_Legado',
     chapters: [
@@ -163,7 +152,7 @@ const CONTENT_MAP = [
   {
     id: 'l5',
     group: 'academia',
-    title: 'L5 — Fogo & Liberdade',
+    title: 'Fogo & Liberdade',
     subtitle: 'Épico, político',
     path: 'Academia Arcana Victory/Suplementos/L5_Fogo_e_Liberdade',
     chapters: [
@@ -182,7 +171,7 @@ const CONTENT_MAP = [
   {
     id: 'l6',
     group: 'academia',
-    title: 'L6 — Laços & Máscaras',
+    title: 'Laços & Máscaras',
     subtitle: 'Shōnen, psicológico',
     path: 'Academia Arcana Victory/Suplementos/L6_Lacos_e_Mascaras',
     chapters: [
@@ -201,7 +190,7 @@ const CONTENT_MAP = [
   {
     id: 'l7',
     group: 'academia',
-    title: 'L7 — Desejos & Portais',
+    title: 'Desejos & Portais',
     subtitle: 'Cômico, colorido',
     path: 'Academia Arcana Victory/Suplementos/L7_Desejos_e_Portais',
     chapters: [


### PR DESCRIPTION
This pull request makes adjustments to both the documentation structure and content for the "Academia Arcana Victory" supplements. The main changes include updating chapter titles for clarity and consistency, removing a redundant overview section, and refining terminology in the campaign framework introduction.

Documentation structure improvements:

* Removed the redundant "Suplementos" overview section from the `CONTENT_MAP` in `docs/js/content-map.js`, streamlining navigation.

Chapter title consistency:

* Updated all supplement chapter titles in `CONTENT_MAP` to remove the "Lx —" prefix, ensuring uniformity and clarity across chapter listings. [[1]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL88-R77) [[2]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL108-R97) [[3]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL128-R117) [[4]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL146-R135) [[5]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL166-R155) [[6]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL185-R174) [[7]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeL204-R193)

Content terminology refinement:

* Revised the introduction in `cap05_progressao_de_vinculo.md` to use "sistemas" instead of "franquias" and updated the recommended subsystems for campaign setup, improving accuracy and alignment with the rest of the documentation.