### PR TITLE
fixing chapter navigation

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -14,7 +14,20 @@
   const btnPrev        = document.getElementById('btn-prev');
   const btnNext        = document.getElementById('btn-next');
 
-  // ── Flat chapter index (for prev/next) ───────────────────────
+  // ── Flat chapter index (for prev/next)
+  // Use filename stem (without .md) as canonical chapter ID so hashes
+  // and internal links (which reference filenames) match reliably.
+  // Normalize CONTENT_MAP: preserve original human-readable id in `label`,
+  // and standardize `id` to the filename stem (without .md).
+  for (const book of CONTENT_MAP) {
+    for (const ch of book.chapters) {
+      // preserve previous id text used in UI
+      if (typeof ch.id === 'string') ch.label = ch.id;
+      // canonical id: stem of filename or existing id string
+      ch.id = ch.file ? ch.file.replace(/\.md$/, '') : String(ch.id);
+    }
+  }
+
   const allChapters = [];
   for (const book of CONTENT_MAP) {
     for (const ch of book.chapters) {
@@ -58,6 +71,7 @@
       for (const book of books) {
         const accent = BOOK_ACCENTS[book.id] || '#c9a84c';
         const firstCh = book.chapters[0];
+        const firstKey = firstCh.file ? firstCh.file.replace(/\.md$/, '') : firstCh.id;
         const chCount = book.chapters.length;
         const isFeatured = book.id === 'livro' || book.id === 'btv-livro';
         const chLabel = chCount === 1 ? '1 capítulo' : `${chCount} capítulos`;
@@ -69,7 +83,7 @@
         const displayTitle = book.title.replace(/^L\d+ — /, '');
 
         html += `<a
-          href="#${book.id}/${firstCh.id}"
+          href="#${book.id}/${firstKey}"
           class="book-card${isFeatured ? ' book-card--featured' : ''}"
           style="--card-accent: ${accent}"
         >
@@ -122,11 +136,12 @@
         </summary>
         <ul class="chapter-list">`;
       for (const ch of book.chapters) {
+        const chKey = ch.file ? ch.file.replace(/\.md$/, '') : ch.id;
         html += `<li><a
-          href="#${book.id}/${ch.id}"
+          href="#${book.id}/${chKey}"
           class="chapter-link"
           data-book="${book.id}"
-          data-chapter="${ch.id}"
+          data-chapter="${chKey}"
         >${ch.title}</a></li>`;
       }
       html += `</ul></details>`;
@@ -163,16 +178,28 @@
   async function navigateTo(bookId, chapterId) {
     const book = CONTENT_MAP.find(b => b.id === bookId);
     if (!book) return;
-    const chapter = book.chapters.find(c => c.id === chapterId);
+    // Find chapter by flexible matching:
+    // - match canonical file stem (e.g. cap01_name)
+    // - match stored id
+    // - tolerate URL-encoded chapterId
+    const chapter = book.chapters.find(c => {
+      const key = c.file ? c.file.replace(/\.md$/, '') : String(c.id);
+      try {
+        return key === chapterId || String(c.id) === chapterId || key === decodeURIComponent(chapterId) || decodeURIComponent(String(c.id)) === chapterId;
+      } catch (e) {
+        return key === chapterId || String(c.id) === chapterId;
+      }
+    });
     if (!chapter) return;
 
-    const newHash = `#${bookId}/${chapterId}`;
+    const canonicalId = chapter.file ? chapter.file.replace(/\.md$/, '') : String(chapter.id);
+
+    const newHash = `#${bookId}/${canonicalId}`;
     if (window.location.hash !== newHash) {
       history.replaceState(null, '', newHash);
     }
-
-    setActiveChapter(bookId, chapterId);
-    updatePrevNext(bookId, chapterId);
+    setActiveChapter(bookId, canonicalId);
+    updatePrevNext(bookId, canonicalId);
     closeSidebar();
 
     contentEl.innerHTML = '<div class="loading">Carregando</div>';

--- a/docs/js/content-map.js
+++ b/docs/js/content-map.js
@@ -18,6 +18,16 @@ const CONTENT_GROUPS = [
   },
 ];
 
+// Normalize chapter ids: preserve existing human-readable `id` into `label`,
+// and set `id` to the filename stem (without .md) for canonical matching.
+for (const book of CONTENT_MAP) {
+  if (!book.chapters) continue;
+  for (const ch of book.chapters) {
+    if (typeof ch.id === 'string') ch.label = ch.id;
+    ch.id = ch.file ? ch.file.replace(/\.md$/, '') : String(ch.id);
+  }
+}
+
 // ── Books ─────────────────────────────────────────────────────
 const CONTENT_MAP = [
 


### PR DESCRIPTION
This pull request standardizes chapter IDs throughout the documentation app to use the filename stem (without the `.md` extension) as the canonical chapter identifier. This change ensures that internal links, hashes, and navigation are consistent and reliable, especially when referencing chapters by their filenames. The previous human-readable IDs are preserved as `label` properties for display purposes. The most important changes are as follows:

**Chapter ID normalization:**
* In both `docs/js/app.js` and `docs/js/content-map.js`, chapter objects are updated so that their `id` property is always set to the filename stem (without `.md`), while the previous human-readable `id` is preserved in a new `label` property. This normalization is performed at initialization for all chapters. [[1]](diffhunk://#diff-063e91478a7595ad85c31f521cd862d68aa03d59ca58cdbf3cbcc7220c1aaabdL17-R30) [[2]](diffhunk://#diff-b354f1aff80a22d2cb585ad13d6d0a5ac3dc017bb2ad75bc17c97323d8895bdeR21-R30)

**Navigation and linking updates:**
* All chapter links, book cards, and navigation logic are updated to use the canonical chapter ID derived from the filename stem, ensuring that URLs and hashes are consistent and match the actual file references. [[1]](diffhunk://#diff-063e91478a7595ad85c31f521cd862d68aa03d59ca58cdbf3cbcc7220c1aaabdL72-R86) [[2]](diffhunk://#diff-063e91478a7595ad85c31f521cd862d68aa03d59ca58cdbf3cbcc7220c1aaabdR139-R144)
* The `navigateTo` function is enhanced to flexibly match chapters by canonical ID, original ID, or URL-encoded forms, improving robustness of navigation and deep linking. The function also updates hashes and navigation state to use the canonical ID.
* Book card links are updated to use the standardized chapter ID for their first chapter, ensuring featured and non-featured books link correctly.