### PR TITLE
bugfixes

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -31,7 +31,7 @@
   const allChapters = [];
   for (const book of CONTENT_MAP) {
     for (const ch of book.chapters) {
-      allChapters.push({ bookId: book.id, chapterId: ch.id, title: ch.title });
+      allChapters.push({ bookId: book.id, chapterId: ch.id, title: (ch.label || ch.title) });
     }
   }
 
@@ -142,7 +142,7 @@
           class="chapter-link"
           data-book="${book.id}"
           data-chapter="${chKey}"
-        >${ch.title}</a></li>`;
+        >${ch.label || ch.title}</a></li>`;
       }
       html += `</ul></details>`;
     }

--- a/docs/js/content-map.js
+++ b/docs/js/content-map.js
@@ -18,16 +18,6 @@ const CONTENT_GROUPS = [
   },
 ];
 
-// Normalize chapter ids: preserve existing human-readable `id` into `label`,
-// and set `id` to the filename stem (without .md) for canonical matching.
-for (const book of CONTENT_MAP) {
-  if (!book.chapters) continue;
-  for (const ch of book.chapters) {
-    if (typeof ch.id === 'string') ch.label = ch.id;
-    ch.id = ch.file ? ch.file.replace(/\.md$/, '') : String(ch.id);
-  }
-}
-
 // ── Books ─────────────────────────────────────────────────────
 const CONTENT_MAP = [
 
@@ -295,3 +285,14 @@ const CONTENT_MAP = [
   },
   */
 ];
+
+  // Normalize chapter ids: preserve existing human-readable `id` into `label`,
+  // and set `id` to the filename stem (without .md) for canonical matching.
+  for (const book of CONTENT_MAP) {
+    if (!book.chapters) continue;
+    for (const ch of book.chapters) {
+      if (typeof ch.id === 'string') ch.label = ch.id;
+      ch.id = ch.file ? ch.file.replace(/\.md$/, '') : String(ch.id);
+    }
+  }
+


### PR DESCRIPTION
This pull request refactors how chapter IDs and labels are handled in the documentation JavaScript files, ensuring more consistent and canonical chapter identification. The normalization logic for chapter IDs has been moved to the end of the `content-map.js` file, and chapter labels are now used in the UI wherever available.

Normalization of chapter IDs and labels:

* Moved the chapter ID normalization logic to after the definition of `CONTENT_MAP` in `docs/js/content-map.js`, ensuring that the normalization occurs after the content is fully defined.
* Removed the previous placement of the normalization logic, which was before the definition of `CONTENT_MAP`, to prevent issues with undefined content.

UI improvements to chapter display:

* Updated `docs/js/app.js` to use `ch.label` (if present) instead of `ch.title` when displaying chapter titles in lists and links, providing more accurate and human-readable chapter names. [[1]](diffhunk://#diff-063e91478a7595ad85c31f521cd862d68aa03d59ca58cdbf3cbcc7220c1aaabdL34-R34) [[2]](diffhunk://#diff-063e91478a7595ad85c31f521cd862d68aa03d59ca58cdbf3cbcc7220c1aaabdL145-R145)