### PR TITLE
fixe links

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -272,10 +272,19 @@
       a.setAttribute('rel', 'noopener noreferrer');
     });
 
+    // Convert links to local .md files into reader hashes. If we're
+    // currently viewing a book, include its id so the link navigates
+    // within the same book (e.g. #AAV-0/cap01_name).
+    const currentHash = window.location.hash.slice(1);
+    const [currentBookId] = currentHash.split('/');
     contentEl.querySelectorAll('a[href$=".md"]').forEach(a => {
       const href = a.getAttribute('href');
-      const stem = href.replace(/.*\//, '').replace('.md', '');
-      a.setAttribute('href', '#' + stem);
+      if (!href) return;
+      // Ignore absolute URLs and fragment-only links
+      if (/^https?:\/\//.test(href) || href.startsWith('#')) return;
+      const stem = href.replace(/.*\//, '').replace(/\.md$/, '');
+      const target = currentBookId ? `#${currentBookId}/${stem}` : `#${stem}`;
+      a.setAttribute('href', target);
     });
   }
 


### PR DESCRIPTION
This pull request introduces an enhancement to link handling in the `docs/js/app.js` file. Now, links to local `.md` files are converted to reader hashes that allow for navigation within the same book context, improving user experience when browsing documentation.

Improvements to link navigation:

* Local `.md` file links are now converted to reader hashes, and if a book is currently being viewed, the book's ID is included in the hash to enable in-book navigation (e.g., `#AAV-0/cap01_name`).
* The code now ignores absolute URLs and fragment-only links when converting `.md` links, ensuring only relevant links are transformed.