### PR TITLE
z

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -109,8 +109,9 @@ body {
 .header-title {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 1px;
   text-decoration: none;
+  padding-left: 1.25rem;
 }
 
 .header-main {


### PR DESCRIPTION
This pull request makes a minor style adjustment to the `.header-title` class in `docs/css/style.css`. The change reduces the gap between elements and adds left padding for improved visual alignment.

* Decreased the `gap` property from 5px to 1px and added `padding-left: 1.25rem` to the `.header-title` class in `docs/css/style.css` for tighter spacing and better alignment.