### PR TITLE
.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -8,36 +8,36 @@
   --sidebar-width: 290px;
   --header-height: 58px;
 
-  --c-sidebar-bg:          #f6f4ef;
-  --c-sidebar-border:      rgba(201, 168, 76, 0.18);
+  --c-sidebar-bg:          #ffffff;
+  --c-sidebar-border:      rgba(101, 28, 116, 0.12);
   --c-sidebar-text:        #1a0820;
-  --c-sidebar-muted:       #9a8a60;
-  --c-sidebar-hover:       #f6f4ef;
-  --c-sidebar-active-bg:   #f7f5f0;
+  --c-sidebar-muted:       #7a6a88;
+  --c-sidebar-hover:       #f7f3ff;
+  --c-sidebar-active-bg:   #ede8ff;
   --c-active-accent:       #651c74;
 
-  --c-header-bg:           #f5f4f0;
-  --c-header-border:       rgba(201, 168, 76, 0.25);
+  --c-header-bg:           #ffffff;
+  --c-header-border:       rgba(101, 28, 116, 0.12);
 
-  --c-content-bg:          #fffefc;
+  --c-content-bg:          #ffffff;
   --c-content-text:        #1a0820;
   --c-heading:             #651c74;
-  --c-heading-2:           #c9a84c;
-  --c-accent:              #c9a84c;
+  --c-heading-2:           #8a6500;   /* darkened gold — AA contrast on white */
+  --c-accent:              #c9a84c;   /* decorative gold (borders, tints) */
   --c-link:                #651c74;
-  --c-link-hover:          #c9a84c;
+  --c-link-hover:          #a07820;
 
-  --c-table-head-bg:       #ede8da;
+  --c-table-head-bg:       #f7f3ff;
   --c-table-head-text:     #1a0820;
-  --c-table-row-alt:       #f7f2e9;
-  --c-table-border:        rgba(201, 168, 76, 0.45);
+  --c-table-row-alt:       #fdfcff;
+  --c-table-border:        rgba(101, 28, 116, 0.12);
 
-  --c-bq-bg:               #f7f2e9;
-  --c-bq-border:           #c9a84c;
+  --c-bq-bg:               #fdf9ff;
+  --c-bq-border:           #651c74;
   --c-bq-text:             #1a0820;
 
-  --c-hr:                  rgba(201, 168, 76, 0.5);
-  --c-code-bg:             #ede8da;
+  --c-hr:                  rgba(101, 28, 116, 0.15);
+  --c-code-bg:             #f7f3ff;
   --c-code-text:           #1a0820;
 
   /* safe area (iOS notch/home indicator) */
@@ -47,9 +47,9 @@
   --safe-area-right: env(safe-area-inset-right);
 
   /* UI bars (header/sidebar/tab) */
-  --bar-bg: rgba(255,255,255,0.6);
-  --bar-border: rgba(0,0,0,0.1);
-  --bar-shadow: 0 1px 0 rgba(0,0,0,0.12);
+  --bar-bg: rgba(255,255,255,0.85);
+  --bar-border: rgba(101, 28, 116, 0.1);
+  --bar-shadow: 0 1px 0 rgba(101, 28, 116, 0.08);
 
   /* Typography */
   --font-heading:          -apple-system, system-ui, 'Segoe UI', sans-serif; /*fallback order for iOS look*/
@@ -315,7 +315,7 @@ body {
 
 /* Content scrollbar */
 #main::-webkit-scrollbar { width: 6px; }
-#main::-webkit-scrollbar-track { background: #ede8da; }
+#main::-webkit-scrollbar-track { background: #f0ecff; }
 #main::-webkit-scrollbar-thumb {
   background: rgba(201, 168, 76, 0.4);
   border-radius: 3px;
@@ -357,7 +357,7 @@ body {
   margin-bottom: 1rem;
   letter-spacing: 0.03em;
   padding-bottom: 0.3rem;
-  border-bottom: 1px solid rgba(201, 168, 76, 0.25);
+  border-bottom: 1px solid rgba(101, 28, 116, 0.15);
 }
 
 .markdown-content h3 {
@@ -477,8 +477,8 @@ body {
 
 /* Nested blockquotes (italicized lore passages) */
 .markdown-content blockquote blockquote {
-  border-left-color: rgba(201, 168, 76, 0.4);
-  background: rgba(237, 232, 218, 0.6);
+  border-left-color: rgba(101, 28, 116, 0.3);
+  background: rgba(247, 243, 255, 0.7);
   margin: 0.75rem 0;
 }
 
@@ -516,7 +516,7 @@ body {
 }
 
 .markdown-content tbody tr:hover {
-  background: #e6e0d0;
+  background: #ede8ff;
 }
 
 .markdown-content tbody td {
@@ -533,12 +533,12 @@ body {
   color: var(--c-code-text);
   padding: 0.12em 0.35em;
   border-radius: 3px;
-  border: 1px solid rgba(201, 168, 76, 0.2);
+  border: 1px solid rgba(101, 28, 116, 0.15);
 }
 
 .markdown-content pre {
   background: var(--c-code-bg);
-  border: 1px solid rgba(201, 168, 76, 0.25);
+  border: 1px solid rgba(101, 28, 116, 0.12);
   border-radius: 6px;
   padding: 1.25rem;
   overflow-x: auto;
@@ -855,9 +855,9 @@ body {
 }
 
 .book-card:hover {
-  background: #f7f2e9;
+  background: #f7f3ff;
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.10);
+  box-shadow: 0 6px 20px rgba(101, 28, 116, 0.12);
 }
 
 .book-card:hover::after {


### PR DESCRIPTION
This pull request updates the color palette and styling for the documentation site, shifting from gold and beige tones to a more purple and white theme. The changes improve visual consistency and accessibility, especially for backgrounds, borders, and interactive elements.

**Theme and color palette updates:**

* Updated CSS variables in `style.css` to use purple and white tones for sidebar, header, content, and accent colors, replacing previous gold/beige values. This includes backgrounds, borders, muted text, hover states, and active backgrounds.
* Changed UI bar colors (`--bar-bg`, `--bar-border`, `--bar-shadow`) to match the new purple theme.

**Component and element styling:**

* Adjusted backgrounds and borders for scrollbars, headings, blockquotes, tables, code blocks, and cards to use the new color scheme. This includes hover states, alternate rows, and nested blockquotes. [[1]](diffhunk://#diff-a5f654ae6e045707ab35bcbd9e31d8351223c408c22ce8c30a234eceaae16952L318-R318) [[2]](diffhunk://#diff-a5f654ae6e045707ab35bcbd9e31d8351223c408c22ce8c30a234eceaae16952L360-R360) [[3]](diffhunk://#diff-a5f654ae6e045707ab35bcbd9e31d8351223c408c22ce8c30a234eceaae16952L480-R481) [[4]](diffhunk://#diff-a5f654ae6e045707ab35bcbd9e31d8351223c408c22ce8c30a234eceaae16952L519-R519) [[5]](diffhunk://#diff-a5f654ae6e045707ab35bcbd9e31d8351223c408c22ce8c30a234eceaae16952L536-R541) [[6]](diffhunk://#diff-a5f654ae6e045707ab35bcbd9e31d8351223c408c22ce8c30a234eceaae16952L858-R860)